### PR TITLE
Change: by default, always run all Dockers with 'make -j2'

### DIFF
--- a/ci-linux-amd64-clang-3.8/files/run.sh
+++ b/ci-linux-amd64-clang-3.8/files/run.sh
@@ -10,4 +10,4 @@ echo "  Arch: amd64"
 echo ""
 
 ./configure --prefix-dir=/usr
-make test
+make -j2 test

--- a/ci-linux-amd64-gcc-6/files/run.sh
+++ b/ci-linux-amd64-gcc-6/files/run.sh
@@ -10,4 +10,4 @@ echo "  Arch: amd64"
 echo ""
 
 ./configure --prefix-dir=/usr
-make test
+make -j2 test

--- a/ci-linux-i386-gcc-6/files/run.sh
+++ b/ci-linux-i386-gcc-6/files/run.sh
@@ -10,4 +10,4 @@ echo "  Arch: i386"
 echo ""
 
 ./configure --prefix-dir=/usr
-make test
+make -j2 test

--- a/release-linux-deb-gcc/files/run.sh
+++ b/release-linux-deb-gcc/files/run.sh
@@ -21,6 +21,6 @@ echo "  Arch: ${ARCH}"
 echo ""
 
 ln -sf os/debian debian && mkdir -p bundles
-fakeroot make -f debian/rules binary
+fakeroot make -j2 -f debian/rules binary
 mv ../*dbg*.deb bundles/${BASENAME}-linux-${DISTRO}-${RELEASE}-${ARCH}-dbg.deb
 mv ../*.deb bundles/${BASENAME}-linux-${DISTRO}-${RELEASE}-${ARCH}.deb

--- a/release-linux-generic-gcc/files/run.sh
+++ b/release-linux-generic-gcc/files/run.sh
@@ -20,5 +20,5 @@ echo ""
 
 mkdir -p bundles
 ./configure --static-icu --without-xdg-basedir --prefix-dir=/usr
-make
+make -j2
 make bundle_gzip bundle_xz BUNDLE_NAME=${BASENAME}-linux-generic-${ARCH}


### PR DESCRIPTION
This speeds up building on most platforms, especially as most
machines have at least two cores available.